### PR TITLE
fix streaming cost tracking

### DIFF
--- a/agentbudget/_patch.py
+++ b/agentbudget/_patch.py
@@ -9,22 +9,23 @@ When the patched method returns a streaming response (``openai.Stream`` or
 ``anthropic.Stream``), the return value is replaced with a wrapper object that:
 
 1. Yields every chunk/event unchanged to the caller.
-2. After the caller exhausts the iterator, records the accumulated cost to
-   the active session.
+2. When iteration ends or the iterator is closed, records any accumulated cost
+   to the active session.
 3. Supports both the for-loop and context-manager usage patterns.
 
-For OpenAI this relies on the caller setting
-``stream_options={"include_usage": True}`` so that token usage appears on the
-final chunk.  If no usage chunk is present, cost tracking is silently skipped
-(no error, no partial cost).
+For OpenAI, the patch auto-injects
+``stream_options={"include_usage": True}`` for streaming calls unless the
+caller already set ``include_usage`` explicitly. OpenAI usage still arrives on
+the final chunk, so tracking remains incomplete if that chunk is never
+received.
 
 For Anthropic, token counts are collected from the ``message_start`` event
 (input tokens) and the ``message_delta`` event (output tokens).
 
-Note: if the stream raises an exception before the usage chunk is received,
-or if the consumer breaks out early, cost cannot be determined and is not
-recorded.  This is a protocol limitation — the usage data is only available
-at the end of the stream.
+Note: ``finally`` blocks let the wrappers record any usage already observed
+before a consumer breaks out of the loop. They cannot recover usage the
+provider never sent. If a stream ends without enough usage data to price it,
+the patch logs a warning so the under-count is visible.
 """
 
 from __future__ import annotations
@@ -32,12 +33,39 @@ from __future__ import annotations
 import asyncio
 import functools
 import logging
+from collections.abc import Mapping
 from typing import Any, Callable, Iterator, AsyncIterator, Optional
 
 logger = logging.getLogger("agentbudget.patch")
 
 # Store original methods so we can unpatch cleanly
 _originals: dict[str, Any] = {}
+
+
+def _maybe_inject_openai_stream_options(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Ensure OpenAI streaming requests ask the API to include usage data.
+
+    OpenAI exposes streaming usage on a final chunk when
+    ``stream_options={"include_usage": True}`` is enabled. Injecting the flag
+    here avoids a common footgun where tracking silently under-counts because
+    the caller forgot that option.
+    """
+    if kwargs.get("stream") is not True:
+        return kwargs
+
+    stream_options = kwargs.get("stream_options")
+    if stream_options is None:
+        updated = dict(kwargs)
+        updated["stream_options"] = {"include_usage": True}
+        return updated
+
+    if isinstance(stream_options, Mapping) and "include_usage" not in stream_options:
+        updated = dict(kwargs)
+        updated["stream_options"] = dict(stream_options)
+        updated["stream_options"]["include_usage"] = True
+        return updated
+
+    return kwargs
 
 
 # ---------------------------------------------------------------------------
@@ -95,10 +123,10 @@ class _OpenAIStreamWrapper:
             for chunk in stream:
                 ...
 
-    Cost is recorded after the consumer exhausts the iterator.  Requires the
-    caller to set ``stream_options={"include_usage": True}`` so that OpenAI
-    includes token counts on the final chunk.  Without it, cost tracking is
-    silently skipped (no error, no partial cost).
+    Cost is finalized in a ``finally`` block so breaking out of the loop still
+    records usage that was already seen. OpenAI usage still arrives on the
+    final chunk, so if that chunk never shows up the wrapper can only warn
+    that tracking was incomplete.
     """
 
     def __init__(self, stream: Any, get_session: Callable) -> None:
@@ -110,20 +138,21 @@ class _OpenAIStreamWrapper:
         prompt_tokens: Optional[int] = None
         completion_tokens: Optional[int] = None
 
-        for chunk in self._stream:
-            if model is None:
-                model = getattr(chunk, "model", None)
-            usage = getattr(chunk, "usage", None)
-            if usage is not None:
-                pt = getattr(usage, "prompt_tokens", None)
-                ct = getattr(usage, "completion_tokens", None)
-                if pt is not None:
-                    prompt_tokens = pt
-                if ct is not None:
-                    completion_tokens = ct
-            yield chunk
-
-        self._record_cost(model, prompt_tokens, completion_tokens)
+        try:
+            for chunk in self._stream:
+                if model is None:
+                    model = getattr(chunk, "model", None)
+                usage = getattr(chunk, "usage", None)
+                if usage is not None:
+                    pt = getattr(usage, "prompt_tokens", None)
+                    ct = getattr(usage, "completion_tokens", None)
+                    if pt is not None:
+                        prompt_tokens = pt
+                    if ct is not None:
+                        completion_tokens = ct
+                yield chunk
+        finally:
+            self._record_cost(model, prompt_tokens, completion_tokens)
 
     def _record_cost(
         self,
@@ -132,17 +161,21 @@ class _OpenAIStreamWrapper:
         completion_tokens: Optional[int],
     ) -> None:
         session = self._get_session()
-        if (
-            session is not None
-            and model
-            and prompt_tokens is not None
-            and completion_tokens is not None
-        ):
+        if session is None:
+            return
+
+        if model and prompt_tokens is not None and completion_tokens is not None:
             try:
                 session.wrap(_FakeLLMResult(model, prompt_tokens, completion_tokens))
             except Exception:
                 logger.debug("Failed to track OpenAI streaming cost", exc_info=True)
                 raise
+            return
+
+        if model is not None or prompt_tokens is not None or completion_tokens is not None:
+            logger.warning(
+                "OpenAI streaming call ended without complete usage data; cost was not tracked."
+            )
 
     def __enter__(self) -> "_OpenAIStreamWrapper":
         return self
@@ -183,31 +216,44 @@ class _AsyncOpenAIStreamWrapper:
         prompt_tokens: Optional[int] = None
         completion_tokens: Optional[int] = None
 
-        async for chunk in self._stream:
-            if model is None:
-                model = getattr(chunk, "model", None)
-            usage = getattr(chunk, "usage", None)
-            if usage is not None:
-                pt = getattr(usage, "prompt_tokens", None)
-                ct = getattr(usage, "completion_tokens", None)
-                if pt is not None:
-                    prompt_tokens = pt
-                if ct is not None:
-                    completion_tokens = ct
-            yield chunk
+        try:
+            async for chunk in self._stream:
+                if model is None:
+                    model = getattr(chunk, "model", None)
+                usage = getattr(chunk, "usage", None)
+                if usage is not None:
+                    pt = getattr(usage, "prompt_tokens", None)
+                    ct = getattr(usage, "completion_tokens", None)
+                    if pt is not None:
+                        prompt_tokens = pt
+                    if ct is not None:
+                        completion_tokens = ct
+                yield chunk
+        finally:
+            self._record_cost(model, prompt_tokens, completion_tokens)
 
+    def _record_cost(
+        self,
+        model: Optional[str],
+        prompt_tokens: Optional[int],
+        completion_tokens: Optional[int],
+    ) -> None:
         session = self._get_session()
-        if (
-            session is not None
-            and model
-            and prompt_tokens is not None
-            and completion_tokens is not None
-        ):
+        if session is None:
+            return
+
+        if model and prompt_tokens is not None and completion_tokens is not None:
             try:
                 session.wrap(_FakeLLMResult(model, prompt_tokens, completion_tokens))
             except Exception:
                 logger.debug("Failed to track OpenAI async streaming cost", exc_info=True)
                 raise
+            return
+
+        if model is not None or prompt_tokens is not None or completion_tokens is not None:
+            logger.warning(
+                "OpenAI streaming call ended without complete usage data; cost was not tracked."
+            )
 
     def __aiter__(self) -> Any:  # type: ignore[misc]
         return self._iterate().__aiter__()
@@ -250,27 +296,28 @@ class _AnthropicStreamWrapper:
         input_tokens: Optional[int] = None
         output_tokens: Optional[int] = None
 
-        for event in self._stream:
-            event_type = getattr(event, "type", None)
-            if event_type == "message_start":
-                msg = getattr(event, "message", None)
-                if msg is not None:
-                    if model is None:
-                        model = getattr(msg, "model", None)
-                    usage = getattr(msg, "usage", None)
+        try:
+            for event in self._stream:
+                event_type = getattr(event, "type", None)
+                if event_type == "message_start":
+                    msg = getattr(event, "message", None)
+                    if msg is not None:
+                        if model is None:
+                            model = getattr(msg, "model", None)
+                        usage = getattr(msg, "usage", None)
+                        if usage is not None:
+                            it = getattr(usage, "input_tokens", None)
+                            if it is not None:
+                                input_tokens = it
+                elif event_type == "message_delta":
+                    usage = getattr(event, "usage", None)
                     if usage is not None:
-                        it = getattr(usage, "input_tokens", None)
-                        if it is not None:
-                            input_tokens = it
-            elif event_type == "message_delta":
-                usage = getattr(event, "usage", None)
-                if usage is not None:
-                    ot = getattr(usage, "output_tokens", None)
-                    if ot is not None:
-                        output_tokens = ot
-            yield event
-
-        self._record_cost(model, input_tokens, output_tokens)
+                        ot = getattr(usage, "output_tokens", None)
+                        if ot is not None:
+                            output_tokens = ot
+                yield event
+        finally:
+            self._record_cost(model, input_tokens, output_tokens)
 
     def _record_cost(
         self,
@@ -279,17 +326,21 @@ class _AnthropicStreamWrapper:
         output_tokens: Optional[int],
     ) -> None:
         session = self._get_session()
-        if (
-            session is not None
-            and model
-            and input_tokens is not None
-            and output_tokens is not None
-        ):
+        if session is None:
+            return
+
+        if model and input_tokens is not None and output_tokens is not None:
             try:
                 session.wrap(_FakeAnthropicResult(model, input_tokens, output_tokens))
             except Exception:
                 logger.debug("Failed to track Anthropic streaming cost", exc_info=True)
                 raise
+            return
+
+        if model is not None or input_tokens is not None or output_tokens is not None:
+            logger.warning(
+                "Anthropic streaming call ended without complete usage data; cost was not tracked."
+            )
 
     def __enter__(self) -> "_AnthropicStreamWrapper":
         return self
@@ -319,38 +370,51 @@ class _AsyncAnthropicStreamWrapper:
         input_tokens: Optional[int] = None
         output_tokens: Optional[int] = None
 
-        async for event in self._stream:
-            event_type = getattr(event, "type", None)
-            if event_type == "message_start":
-                msg = getattr(event, "message", None)
-                if msg is not None:
-                    if model is None:
-                        model = getattr(msg, "model", None)
-                    usage = getattr(msg, "usage", None)
+        try:
+            async for event in self._stream:
+                event_type = getattr(event, "type", None)
+                if event_type == "message_start":
+                    msg = getattr(event, "message", None)
+                    if msg is not None:
+                        if model is None:
+                            model = getattr(msg, "model", None)
+                        usage = getattr(msg, "usage", None)
+                        if usage is not None:
+                            it = getattr(usage, "input_tokens", None)
+                            if it is not None:
+                                input_tokens = it
+                elif event_type == "message_delta":
+                    usage = getattr(event, "usage", None)
                     if usage is not None:
-                        it = getattr(usage, "input_tokens", None)
-                        if it is not None:
-                            input_tokens = it
-            elif event_type == "message_delta":
-                usage = getattr(event, "usage", None)
-                if usage is not None:
-                    ot = getattr(usage, "output_tokens", None)
-                    if ot is not None:
-                        output_tokens = ot
-            yield event
+                        ot = getattr(usage, "output_tokens", None)
+                        if ot is not None:
+                            output_tokens = ot
+                yield event
+        finally:
+            self._record_cost(model, input_tokens, output_tokens)
 
+    def _record_cost(
+        self,
+        model: Optional[str],
+        input_tokens: Optional[int],
+        output_tokens: Optional[int],
+    ) -> None:
         session = self._get_session()
-        if (
-            session is not None
-            and model
-            and input_tokens is not None
-            and output_tokens is not None
-        ):
+        if session is None:
+            return
+
+        if model and input_tokens is not None and output_tokens is not None:
             try:
                 session.wrap(_FakeAnthropicResult(model, input_tokens, output_tokens))
             except Exception:
                 logger.debug("Failed to track Anthropic async streaming cost", exc_info=True)
                 raise
+            return
+
+        if model is not None or input_tokens is not None or output_tokens is not None:
+            logger.warning(
+                "Anthropic streaming call ended without complete usage data; cost was not tracked."
+            )
 
     def __aiter__(self) -> Any:
         return self._iterate().__aiter__()
@@ -395,11 +459,17 @@ def _wrap_anthropic_async_stream(stream: Any, get_session: Callable) -> "_AsyncA
 # Sync/async method wrappers (patched onto SDK classes)
 # ---------------------------------------------------------------------------
 
-def _wrap_method(original: Callable, get_session: Callable) -> Callable:
+def _wrap_method(
+    original: Callable,
+    get_session: Callable,
+    provider: Optional[str] = None,
+) -> Callable:
     """Wrap a sync SDK method to auto-track costs (streaming and non-streaming)."""
 
     @functools.wraps(original)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if provider == "openai":
+            kwargs = _maybe_inject_openai_stream_options(kwargs)
         response = original(*args, **kwargs)
         session = get_session()
         if session is None:
@@ -433,11 +503,17 @@ def _wrap_method(original: Callable, get_session: Callable) -> Callable:
     return wrapper
 
 
-def _wrap_async_method(original: Callable, get_session: Callable) -> Callable:
+def _wrap_async_method(
+    original: Callable,
+    get_session: Callable,
+    provider: Optional[str] = None,
+) -> Callable:
     """Wrap an async SDK method to auto-track costs (streaming and non-streaming)."""
 
     @functools.wraps(original)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if provider == "openai":
+            kwargs = _maybe_inject_openai_stream_options(kwargs)
         response = await original(*args, **kwargs)
         session = get_session()
         if session is None:
@@ -490,12 +566,12 @@ def patch_openai(get_session: Callable) -> bool:
         return True  # already patched
 
     _originals["openai.chat.completions.create"] = Completions.create
-    Completions.create = _wrap_method(Completions.create, get_session)  # type: ignore[assignment]
+    Completions.create = _wrap_method(Completions.create, get_session, provider="openai")  # type: ignore[assignment]
 
     # Patch async if available
     if hasattr(Completions, "acreate"):
         _originals["openai.chat.completions.acreate"] = Completions.acreate
-        Completions.acreate = _wrap_async_method(Completions.acreate, get_session)  # type: ignore[assignment]
+        Completions.acreate = _wrap_async_method(Completions.acreate, get_session, provider="openai")  # type: ignore[assignment]
 
     # Also patch the async completions class if it exists
     try:
@@ -503,7 +579,7 @@ def patch_openai(get_session: Callable) -> bool:
 
         if not getattr(getattr(AsyncCompletions, "create", None), "_agentbudget_patched", False):
             _originals["openai.async_chat.completions.create"] = AsyncCompletions.create
-            AsyncCompletions.create = _wrap_async_method(AsyncCompletions.create, get_session)  # type: ignore[assignment]
+            AsyncCompletions.create = _wrap_async_method(AsyncCompletions.create, get_session, provider="openai")  # type: ignore[assignment]
     except ImportError:
         pass
 
@@ -526,7 +602,7 @@ def patch_anthropic(get_session: Callable) -> bool:
         return True  # already patched
 
     _originals["anthropic.messages.create"] = Messages.create
-    Messages.create = _wrap_method(Messages.create, get_session)  # type: ignore[assignment]
+    Messages.create = _wrap_method(Messages.create, get_session, provider="anthropic")  # type: ignore[assignment]
 
     # Patch async messages
     try:
@@ -534,7 +610,7 @@ def patch_anthropic(get_session: Callable) -> bool:
 
         if not getattr(getattr(AsyncMessages, "create", None), "_agentbudget_patched", False):
             _originals["anthropic.async_messages.create"] = AsyncMessages.create
-            AsyncMessages.create = _wrap_async_method(AsyncMessages.create, get_session)  # type: ignore[assignment]
+            AsyncMessages.create = _wrap_async_method(AsyncMessages.create, get_session, provider="anthropic")  # type: ignore[assignment]
     except ImportError:
         pass
 
@@ -574,9 +650,9 @@ def wrap_client(client: Any, session: Any) -> Any:
             original_create = completions.__class__.create
 
             if class_name == "AsyncOpenAI":
-                wrapped = _wrap_async_method(original_create, get_session)
+                wrapped = _wrap_async_method(original_create, get_session, provider="openai")
             else:
-                wrapped = _wrap_method(original_create, get_session)
+                wrapped = _wrap_method(original_create, get_session, provider="openai")
 
             # Bind the wrapped method to this instance's completions object
             import types
@@ -590,9 +666,9 @@ def wrap_client(client: Any, session: Any) -> Any:
             original_create = messages.__class__.create
 
             if class_name == "AsyncAnthropic":
-                wrapped = _wrap_async_method(original_create, get_session)
+                wrapped = _wrap_async_method(original_create, get_session, provider="anthropic")
             else:
-                wrapped = _wrap_method(original_create, get_session)
+                wrapped = _wrap_method(original_create, get_session, provider="anthropic")
 
             import types
             messages.create = types.MethodType(wrapped, messages)  # type: ignore[assignment]

--- a/agentbudget/_patch.py
+++ b/agentbudget/_patch.py
@@ -205,58 +205,85 @@ class _AsyncOpenAIStreamWrapper:
         async with await client.chat.completions.create(stream=True) as stream:
             async for chunk in stream:
                 ...
+
+    State is stored on ``self`` so that ``aclose()`` / ``__aexit__`` can
+    record accumulated usage even when the caller breaks out of the loop
+    early.  The old ``_iterate()`` async-generator approach caused the
+    ``finally`` block to run inside a generator that was scheduled for
+    collection rather than running synchronously, which lost the cost.
     """
 
     def __init__(self, stream: Any, get_session: Callable) -> None:
         self._stream = stream
         self._get_session = get_session
+        self._aiter: Optional[Any] = None
+        # Accumulated usage state
+        self._model: Optional[str] = None
+        self._prompt_tokens: Optional[int] = None
+        self._completion_tokens: Optional[int] = None
+        self._cost_recorded: bool = False
 
-    async def _iterate(self) -> AsyncIterator:
-        model: Optional[str] = None
-        prompt_tokens: Optional[int] = None
-        completion_tokens: Optional[int] = None
+    def __aiter__(self) -> "_AsyncOpenAIStreamWrapper":
+        self._aiter = self._stream.__aiter__()
+        return self
 
+    async def __anext__(self) -> Any:
         try:
-            async for chunk in self._stream:
-                if model is None:
-                    model = getattr(chunk, "model", None)
-                usage = getattr(chunk, "usage", None)
-                if usage is not None:
-                    pt = getattr(usage, "prompt_tokens", None)
-                    ct = getattr(usage, "completion_tokens", None)
-                    if pt is not None:
-                        prompt_tokens = pt
-                    if ct is not None:
-                        completion_tokens = ct
-                yield chunk
-        finally:
-            self._record_cost(model, prompt_tokens, completion_tokens)
+            chunk = await self._aiter.__anext__()
+        except StopAsyncIteration:
+            self._record_cost()
+            raise
+        if self._model is None:
+            self._model = getattr(chunk, "model", None)
+        usage = getattr(chunk, "usage", None)
+        if usage is not None:
+            pt = getattr(usage, "prompt_tokens", None)
+            ct = getattr(usage, "completion_tokens", None)
+            if pt is not None:
+                self._prompt_tokens = pt
+            if ct is not None:
+                self._completion_tokens = ct
+        # Record eagerly once we have complete data so that a caller who
+        # breaks immediately after seeing the usage chunk still gets tracked.
+        if (
+            self._model
+            and self._prompt_tokens is not None
+            and self._completion_tokens is not None
+            and not self._cost_recorded
+        ):
+            self._record_cost()
+        return chunk
 
-    def _record_cost(
-        self,
-        model: Optional[str],
-        prompt_tokens: Optional[int],
-        completion_tokens: Optional[int],
-    ) -> None:
+    def _record_cost(self) -> None:
+        if self._cost_recorded:
+            return
+        self._cost_recorded = True
         session = self._get_session()
         if session is None:
             return
 
-        if model and prompt_tokens is not None and completion_tokens is not None:
+        if (
+            self._model
+            and self._prompt_tokens is not None
+            and self._completion_tokens is not None
+        ):
             try:
-                session.wrap(_FakeLLMResult(model, prompt_tokens, completion_tokens))
+                session.wrap(
+                    _FakeLLMResult(self._model, self._prompt_tokens, self._completion_tokens)
+                )
             except Exception:
                 logger.debug("Failed to track OpenAI async streaming cost", exc_info=True)
                 raise
             return
 
-        if model is not None or prompt_tokens is not None or completion_tokens is not None:
+        if (
+            self._model is not None
+            or self._prompt_tokens is not None
+            or self._completion_tokens is not None
+        ):
             logger.warning(
                 "OpenAI streaming call ended without complete usage data; cost was not tracked."
             )
-
-    def __aiter__(self) -> Any:  # type: ignore[misc]
-        return self._iterate().__aiter__()
 
     async def __aenter__(self) -> "_AsyncOpenAIStreamWrapper":
         return self
@@ -265,7 +292,8 @@ class _AsyncOpenAIStreamWrapper:
         await self.aclose()
 
     async def aclose(self) -> None:
-        """Close the underlying stream (matches AsyncStream.close() interface)."""
+        """Record accumulated cost then close the underlying stream."""
+        self._record_cost()
         close = getattr(self._stream, "aclose", None) or getattr(self._stream, "close", None)
         if close is not None:
             try:
@@ -359,65 +387,91 @@ class _AnthropicStreamWrapper:
 
 
 class _AsyncAnthropicStreamWrapper:
-    """Wraps an async Anthropic ``AsyncStream[RawMessageStreamEvent]``."""
+    """Wraps an async Anthropic ``AsyncStream[RawMessageStreamEvent]``.
+
+    Like ``_AsyncOpenAIStreamWrapper``, state is stored on ``self`` rather
+    than inside an async generator so that ``aclose()`` can flush any
+    accumulated cost when the caller breaks out of the loop early.
+    """
 
     def __init__(self, stream: Any, get_session: Callable) -> None:
         self._stream = stream
         self._get_session = get_session
+        self._aiter: Optional[Any] = None
+        # Accumulated usage state
+        self._model: Optional[str] = None
+        self._input_tokens: Optional[int] = None
+        self._output_tokens: Optional[int] = None
+        self._cost_recorded: bool = False
 
-    async def _iterate(self) -> AsyncIterator:
-        model: Optional[str] = None
-        input_tokens: Optional[int] = None
-        output_tokens: Optional[int] = None
+    def __aiter__(self) -> "_AsyncAnthropicStreamWrapper":
+        self._aiter = self._stream.__aiter__()
+        return self
 
+    async def __anext__(self) -> Any:
         try:
-            async for event in self._stream:
-                event_type = getattr(event, "type", None)
-                if event_type == "message_start":
-                    msg = getattr(event, "message", None)
-                    if msg is not None:
-                        if model is None:
-                            model = getattr(msg, "model", None)
-                        usage = getattr(msg, "usage", None)
-                        if usage is not None:
-                            it = getattr(usage, "input_tokens", None)
-                            if it is not None:
-                                input_tokens = it
-                elif event_type == "message_delta":
-                    usage = getattr(event, "usage", None)
-                    if usage is not None:
-                        ot = getattr(usage, "output_tokens", None)
-                        if ot is not None:
-                            output_tokens = ot
-                yield event
-        finally:
-            self._record_cost(model, input_tokens, output_tokens)
+            event = await self._aiter.__anext__()
+        except StopAsyncIteration:
+            self._record_cost()
+            raise
+        event_type = getattr(event, "type", None)
+        if event_type == "message_start":
+            msg = getattr(event, "message", None)
+            if msg is not None:
+                if self._model is None:
+                    self._model = getattr(msg, "model", None)
+                usage = getattr(msg, "usage", None)
+                if usage is not None:
+                    it = getattr(usage, "input_tokens", None)
+                    if it is not None:
+                        self._input_tokens = it
+        elif event_type == "message_delta":
+            usage = getattr(event, "usage", None)
+            if usage is not None:
+                ot = getattr(usage, "output_tokens", None)
+                if ot is not None:
+                    self._output_tokens = ot
+        # Record eagerly once both input and output usage are known so that a
+        # caller who breaks after the message_delta event still gets tracked.
+        if (
+            self._model
+            and self._input_tokens is not None
+            and self._output_tokens is not None
+            and not self._cost_recorded
+        ):
+            self._record_cost()
+        return event
 
-    def _record_cost(
-        self,
-        model: Optional[str],
-        input_tokens: Optional[int],
-        output_tokens: Optional[int],
-    ) -> None:
+    def _record_cost(self) -> None:
+        if self._cost_recorded:
+            return
+        self._cost_recorded = True
         session = self._get_session()
         if session is None:
             return
 
-        if model and input_tokens is not None and output_tokens is not None:
+        if (
+            self._model
+            and self._input_tokens is not None
+            and self._output_tokens is not None
+        ):
             try:
-                session.wrap(_FakeAnthropicResult(model, input_tokens, output_tokens))
+                session.wrap(
+                    _FakeAnthropicResult(self._model, self._input_tokens, self._output_tokens)
+                )
             except Exception:
                 logger.debug("Failed to track Anthropic async streaming cost", exc_info=True)
                 raise
             return
 
-        if model is not None or input_tokens is not None or output_tokens is not None:
+        if (
+            self._model is not None
+            or self._input_tokens is not None
+            or self._output_tokens is not None
+        ):
             logger.warning(
                 "Anthropic streaming call ended without complete usage data; cost was not tracked."
             )
-
-    def __aiter__(self) -> Any:
-        return self._iterate().__aiter__()
 
     async def __aenter__(self) -> "_AsyncAnthropicStreamWrapper":
         return self
@@ -426,7 +480,8 @@ class _AsyncAnthropicStreamWrapper:
         await self.aclose()
 
     async def aclose(self) -> None:
-        """Close the underlying stream (matches AsyncStream.close() interface)."""
+        """Record accumulated cost then close the underlying stream."""
+        self._record_cost()
         close = getattr(self._stream, "aclose", None) or getattr(self._stream, "close", None)
         if close is not None:
             try:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3,7 +3,7 @@
 Covers:
 - OpenAI sync streaming (usage in final chunk)
 - OpenAI async streaming
-- OpenAI streaming with no usage chunk (cost silently skipped)
+- OpenAI streaming with no usage chunk (cost skipped with warning)
 - Anthropic sync streaming (usage from message_start + message_delta events)
 - Anthropic async streaming
 - BudgetExhausted raised during streaming consumption
@@ -12,6 +12,7 @@ Covers:
 
 from __future__ import annotations
 
+import logging
 import sys
 import types
 from typing import Iterator, AsyncIterator
@@ -134,7 +135,7 @@ def test_openai_stream_records_cost():
 
 
 def test_openai_stream_no_usage_skips_cost():
-    """If the stream has no usage chunk, cost is silently skipped (no error)."""
+    """If the stream has no usage chunk, cost is skipped and a warning is logged."""
     budget = AgentBudget(max_spend="$5.00")
     with budget.session() as session:
         stream = _wrap_openai_stream(_openai_chunks_no_usage(), lambda: session)
@@ -142,6 +143,38 @@ def test_openai_stream_no_usage_skips_cost():
 
     assert len(chunks) == 2
     assert session.spent == 0.0
+
+
+def test_openai_stream_break_after_usage_chunk_records_cost():
+    """Breaking after the final usage chunk should still record cost via finally."""
+    budget = AgentBudget(max_spend="$5.00")
+    with budget.session() as session:
+        stream = _wrap_openai_stream(
+            _openai_chunks("gpt-4o", prompt_tokens=1000, completion_tokens=500),
+            lambda: session,
+        )
+
+        seen = 0
+        for chunk in stream:
+            seen += 1
+            if chunk.usage is not None:
+                break
+
+    assert seen == 3
+    assert session.spent == pytest.approx(0.0075, rel=1e-4)
+
+
+def test_openai_stream_no_usage_logs_warning(caplog):
+    """A warning makes missing usage visible instead of silently under-counting."""
+    budget = AgentBudget(max_spend="$5.00")
+    with budget.session() as session:
+        with caplog.at_level(logging.WARNING, logger="agentbudget.patch"):
+            stream = _wrap_openai_stream(_openai_chunks_no_usage(), lambda: session)
+            chunks = list(stream)
+
+    assert len(chunks) == 2
+    assert session.spent == 0.0
+    assert "OpenAI streaming call ended without complete usage data" in caplog.text
 
 
 def test_openai_stream_passthrough():
@@ -217,6 +250,25 @@ async def test_openai_async_stream_no_usage_skips_cost():
     assert len(chunks) == 2
 
 
+@pytest.mark.asyncio
+async def test_openai_async_stream_break_after_usage_chunk_records_cost():
+    budget = AgentBudget(max_spend="$5.00")
+    async with budget.async_session() as session:
+        stream = _wrap_openai_async_stream(
+            _openai_async_chunks("gpt-4o", 1000, 500),
+            lambda: session,
+        )
+
+        seen = 0
+        async for chunk in stream:
+            seen += 1
+            if chunk.usage is not None:
+                break
+
+    assert seen == 3
+    assert session.spent == pytest.approx(0.0075, rel=1e-4)
+
+
 # ---------------------------------------------------------------------------
 # Anthropic sync streaming tests
 # ---------------------------------------------------------------------------
@@ -253,6 +305,25 @@ def test_anthropic_stream_no_session_is_noop():
     assert len(events) == 4
 
 
+def test_anthropic_stream_break_after_usage_event_records_cost():
+    """Anthropic can recover cost once both input and output usage were seen."""
+    budget = AgentBudget(max_spend="$5.00")
+    with budget.session() as session:
+        stream = _wrap_anthropic_stream(
+            _anthropic_events("claude-3-5-sonnet-20241022", input_tokens=1000, output_tokens=500),
+            lambda: session,
+        )
+
+        seen = 0
+        for event in stream:
+            seen += 1
+            if getattr(event, "type", None) == "message_delta":
+                break
+
+    assert seen == 3
+    assert session.spent == pytest.approx(0.0105, rel=1e-4)
+
+
 # ---------------------------------------------------------------------------
 # Anthropic async streaming tests
 # ---------------------------------------------------------------------------
@@ -275,6 +346,25 @@ async def test_anthropic_async_stream_records_cost():
         events = [e async for e in stream]
 
     assert len(events) == 4
+    assert session.spent == pytest.approx(0.0105, rel=1e-4)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_async_stream_break_after_usage_event_records_cost():
+    budget = AgentBudget(max_spend="$5.00")
+    async with budget.async_session() as session:
+        stream = _wrap_anthropic_async_stream(
+            _anthropic_async_events("claude-3-5-sonnet-20241022", 1000, 500),
+            lambda: session,
+        )
+
+        seen = 0
+        async for event in stream:
+            seen += 1
+            if getattr(event, "type", None) == "message_delta":
+                break
+
+    assert seen == 3
     assert session.spent == pytest.approx(0.0105, rel=1e-4)
 
 
@@ -474,3 +564,67 @@ def test_dropin_patches_openai_streaming():
             assert agentbudget.spent() == pytest.approx(0.0075, rel=1e-4)
         finally:
             agentbudget.teardown()
+
+
+def test_wrap_method_injects_openai_stream_usage_option():
+    """The OpenAI patch should request usage automatically for streaming calls."""
+    captured_kwargs = {}
+
+    class FakeStream:
+        def __iter__(self):
+            return iter(_openai_chunks("gpt-4o", 1000, 500))
+
+    def fake_create(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return FakeStream()
+
+    from agentbudget._patch import _wrap_method
+
+    patched_create = _wrap_method(fake_create, lambda: None, provider="openai")
+    patched_create(stream=True)
+
+    assert captured_kwargs["stream_options"] == {"include_usage": True}
+
+
+def test_wrap_method_preserves_explicit_openai_stream_usage_option():
+    """Caller-provided include_usage should not be overwritten by the patch."""
+    captured_kwargs = {}
+
+    class FakeStream:
+        def __iter__(self):
+            return iter(_openai_chunks("gpt-4o", 1000, 500))
+
+    def fake_create(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return FakeStream()
+
+    from agentbudget._patch import _wrap_method
+
+    patched_create = _wrap_method(fake_create, lambda: None, provider="openai")
+    patched_create(stream=True, stream_options={"include_usage": False, "foo": "bar"})
+
+    assert captured_kwargs["stream_options"] == {"include_usage": False, "foo": "bar"}
+
+
+@pytest.mark.asyncio
+async def test_wrap_async_method_injects_openai_stream_usage_option():
+    """The async OpenAI patch should mirror the sync kwargs injection logic."""
+    captured_kwargs = {}
+
+    class FakeAsyncStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    async def fake_create(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return FakeAsyncStream()
+
+    from agentbudget._patch import _wrap_async_method
+
+    patched_create = _wrap_async_method(fake_create, lambda: None, provider="openai")
+    await patched_create(stream=True)
+
+    assert captured_kwargs["stream_options"] == {"include_usage": True}


### PR DESCRIPTION
Fixes #14 
What this PR does

This PR makes streaming cost tracking more reliable.

Before this change, AgentBudget only recorded streaming cost after the stream
finished normally. That caused a problem when code stopped reading the stream
early or when the stream ended without complete usage data. In those cases,
some spending could be missed.

This PR improves that behavior in three ways:

1. It records streaming cost in cleanup code, so if the caller breaks out of
   the loop after usage has already been seen, the cost is still saved.

2. It automatically adds OpenAI's
   stream_options={"include_usage": True} for streaming calls when the caller
   did not set that option. This helps avoid missing usage data by accident.

3. It logs a warning when a stream ends without enough usage information to
   calculate cost, instead of failing silently.

Important limitation

This change does not make streaming tracking perfect in every failure case.
If the provider never sends usage data, AgentBudget still cannot guess the
exact token counts. In that case, the warning makes the missing tracking
visible.

Why this matters

AgentBudget is meant to help track real LLM spending. If streaming spend is
missed silently, budget reports can be lower than the real cost. That makes
budget enforcement and debugging less trustworthy.

Tests

I added tests for:

- breaking out of OpenAI streams after usage is seen
- breaking out of Anthropic streams after usage is seen
- warning logs when usage data is incomplete
- automatic OpenAI stream option injection
- preserving caller-provided stream options

Validation

Ran:

python3 -m pytest tests/test_streaming.py tests/test_unit.py -q