### PR TITLE
fix: reject negative, NaN, and infinite cost values

### DIFF
--- a/agentbudget/__init__.py
+++ b/agentbudget/__init__.py
@@ -3,7 +3,7 @@
 __version__ = "0.3.0"
 
 from .budget import AgentBudget
-from .exceptions import AgentBudgetError, BudgetExhausted, InvalidBudget
+from .exceptions import AgentBudgetError, BudgetExhausted, InvalidBudget, InvalidCost
 from .session import AsyncBudgetSession, BudgetSession, LoopDetected
 from .pricing import register_model, register_models
 
@@ -29,6 +29,7 @@ __all__ = [
     "BudgetExhausted",
     "BudgetSession",
     "InvalidBudget",
+    "InvalidCost",
     "LoopDetected",
     # Pricing
     "register_model",

--- a/agentbudget/exceptions.py
+++ b/agentbudget/exceptions.py
@@ -22,3 +22,14 @@ class InvalidBudget(AgentBudgetError):
     def __init__(self, value: str):
         self.value = value
         super().__init__(f"Invalid budget value: {value!r}")
+
+
+class InvalidCost(AgentBudgetError):
+    """Raised when a tracked cost value is not finite and non-negative."""
+
+    def __init__(self, cost: float):
+        self.cost = cost
+        super().__init__(
+            f"Invalid cost value: {cost!r}. "
+            "Cost must be a finite, non-negative number."
+        )

--- a/agentbudget/ledger.py
+++ b/agentbudget/ledger.py
@@ -2,11 +2,24 @@
 
 from __future__ import annotations
 
+import math
 import threading
 from typing import Any
 
-from .exceptions import BudgetExhausted
+from .exceptions import BudgetExhausted, InvalidCost
 from .types import CostEvent, CostType
+
+
+def validate_cost(cost: float) -> None:
+    """Validate that a cost value is finite and non-negative.
+
+    Raises :class:`InvalidCost` for negative numbers, ``NaN``,
+    positive infinity, or negative infinity.
+    """
+    if not isinstance(cost, (int, float)):
+        raise InvalidCost(cost)
+    if math.isnan(cost) or math.isinf(cost) or cost < 0:
+        raise InvalidCost(cost)
 
 
 class Ledger:
@@ -38,7 +51,13 @@ class Ledger:
             return list(self._events)
 
     def record(self, event: CostEvent) -> None:
-        """Record a cost event. Raises BudgetExhausted if budget exceeded."""
+        """Record a cost event.
+
+        Raises :class:`InvalidCost` if the event cost is not finite and
+        non-negative.  Raises :class:`BudgetExhausted` if the budget
+        would be exceeded.
+        """
+        validate_cost(event.cost)
         with self._lock:
             new_total = self._spent + event.cost
             if new_total > self._budget:
@@ -47,7 +66,11 @@ class Ledger:
             self._events.append(event)
 
     def would_exceed(self, cost: float) -> bool:
-        """Check if a cost would exceed the budget without recording it."""
+        """Check if a cost would exceed the budget without recording it.
+
+        Raises :class:`InvalidCost` if *cost* is not finite and non-negative.
+        """
+        validate_cost(cost)
         with self._lock:
             return (self._spent + cost) > self._budget
 

--- a/agentbudget/session.py
+++ b/agentbudget/session.py
@@ -7,7 +7,7 @@ from typing import Any, Optional, TypeVar
 
 from .circuit_breaker import CircuitBreaker
 from .exceptions import BudgetExhausted
-from .ledger import Ledger
+from .ledger import Ledger, validate_cost
 from .pricing import calculate_llm_cost
 from .types import CostEvent, CostType, generate_session_id
 
@@ -65,6 +65,9 @@ class BudgetSession:
 
     def would_exceed(self, estimated_cost: float) -> bool:
         """Check if a cost would exceed the remaining budget without recording it.
+
+        Raises :class:`~agentbudget.exceptions.InvalidCost` if
+        *estimated_cost* is negative, ``NaN``, or infinite.
 
         Use this before a final LLM call to avoid hard-limit termination mid-task:
 
@@ -133,7 +136,11 @@ class BudgetSession:
 
         Returns the result passthrough so it can be used inline:
             data = session.track(call_api(), cost=0.01, tool_name="my_api")
+
+        Raises :class:`~agentbudget.exceptions.InvalidCost` if *cost* is
+        negative, ``NaN``, or infinite.
         """
+        validate_cost(cost)
         event = CostEvent(
             cost=cost,
             cost_type=CostType.TOOL,

--- a/tests/test_cost_validation.py
+++ b/tests/test_cost_validation.py
@@ -1,0 +1,235 @@
+"""Tests for cost validation — negative, NaN, and infinite cost rejection.
+
+Covers the fix for:
+  https://github.com/AgentBudget/agentbudget/issues/21
+"""
+
+import math
+
+import pytest
+
+from agentbudget.exceptions import InvalidCost
+from agentbudget.ledger import Ledger, validate_cost
+from agentbudget.session import BudgetSession
+from agentbudget.types import CostEvent, CostType
+
+
+# ---------------------------------------------------------------------------
+# validate_cost() unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateCost:
+    """Direct tests for the validate_cost helper."""
+
+    def test_zero_is_valid(self):
+        validate_cost(0.0)
+
+    def test_positive_float_is_valid(self):
+        validate_cost(1.23)
+
+    def test_positive_int_is_valid(self):
+        validate_cost(5)
+
+    def test_negative_raises(self):
+        with pytest.raises(InvalidCost):
+            validate_cost(-1.0)
+
+    def test_negative_small_raises(self):
+        with pytest.raises(InvalidCost):
+            validate_cost(-0.001)
+
+    def test_nan_raises(self):
+        with pytest.raises(InvalidCost):
+            validate_cost(float("nan"))
+
+    def test_positive_inf_raises(self):
+        with pytest.raises(InvalidCost):
+            validate_cost(float("inf"))
+
+    def test_negative_inf_raises(self):
+        with pytest.raises(InvalidCost):
+            validate_cost(float("-inf"))
+
+    def test_math_nan_raises(self):
+        with pytest.raises(InvalidCost):
+            validate_cost(math.nan)
+
+    def test_math_inf_raises(self):
+        with pytest.raises(InvalidCost):
+            validate_cost(math.inf)
+
+
+# ---------------------------------------------------------------------------
+# Ledger.record() validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestLedgerRecordValidation:
+    """Ensure Ledger.record() rejects invalid cost values."""
+
+    def _make_event(self, cost: float) -> CostEvent:
+        return CostEvent(cost=cost, cost_type=CostType.TOOL, tool_name="test")
+
+    def test_negative_cost_rejected(self):
+        ledger = Ledger(budget=5.0)
+        with pytest.raises(InvalidCost):
+            ledger.record(self._make_event(-1.0))
+
+    def test_nan_cost_rejected(self):
+        ledger = Ledger(budget=5.0)
+        with pytest.raises(InvalidCost):
+            ledger.record(self._make_event(float("nan")))
+
+    def test_positive_inf_cost_rejected(self):
+        ledger = Ledger(budget=5.0)
+        with pytest.raises(InvalidCost):
+            ledger.record(self._make_event(float("inf")))
+
+    def test_negative_inf_cost_rejected(self):
+        ledger = Ledger(budget=5.0)
+        with pytest.raises(InvalidCost):
+            ledger.record(self._make_event(float("-inf")))
+
+    def test_invalid_cost_does_not_mutate_spent(self):
+        ledger = Ledger(budget=5.0)
+        ledger.record(self._make_event(1.0))  # valid
+        assert ledger.spent == 1.0
+
+        with pytest.raises(InvalidCost):
+            ledger.record(self._make_event(-5.0))
+
+        # Spent must remain unchanged after invalid record attempt
+        assert ledger.spent == 1.0
+        assert ledger.remaining == 4.0
+
+    def test_invalid_cost_does_not_add_event(self):
+        ledger = Ledger(budget=5.0)
+        ledger.record(self._make_event(1.0))
+        assert len(ledger.events) == 1
+
+        with pytest.raises(InvalidCost):
+            ledger.record(self._make_event(float("nan")))
+
+        assert len(ledger.events) == 1
+
+    def test_invalid_cost_does_not_corrupt_breakdown(self):
+        ledger = Ledger(budget=5.0)
+        ledger.record(self._make_event(1.0))
+
+        with pytest.raises(InvalidCost):
+            ledger.record(self._make_event(-2.0))
+
+        bd = ledger.breakdown()
+        assert bd["tools"]["total"] == 1.0
+        assert bd["tools"]["calls"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Ledger.would_exceed() validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestLedgerWouldExceedValidation:
+    def test_negative_cost_rejected(self):
+        ledger = Ledger(budget=5.0)
+        with pytest.raises(InvalidCost):
+            ledger.would_exceed(-1.0)
+
+    def test_nan_cost_rejected(self):
+        ledger = Ledger(budget=5.0)
+        with pytest.raises(InvalidCost):
+            ledger.would_exceed(float("nan"))
+
+    def test_inf_cost_rejected(self):
+        ledger = Ledger(budget=5.0)
+        with pytest.raises(InvalidCost):
+            ledger.would_exceed(float("inf"))
+
+
+# ---------------------------------------------------------------------------
+# BudgetSession.track() validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestSessionTrackValidation:
+    """Ensure session.track() rejects invalid costs at the API boundary."""
+
+    def test_negative_cost_rejected(self):
+        ledger = Ledger(budget=5.0)
+        with BudgetSession(ledger) as session:
+            with pytest.raises(InvalidCost):
+                session.track("result", cost=-1.0, tool_name="api")
+
+    def test_nan_cost_rejected(self):
+        ledger = Ledger(budget=5.0)
+        with BudgetSession(ledger) as session:
+            with pytest.raises(InvalidCost):
+                session.track("result", cost=float("nan"), tool_name="api")
+
+    def test_inf_cost_rejected(self):
+        ledger = Ledger(budget=5.0)
+        with BudgetSession(ledger) as session:
+            with pytest.raises(InvalidCost):
+                session.track("result", cost=float("inf"), tool_name="api")
+
+    def test_negative_inf_cost_rejected(self):
+        ledger = Ledger(budget=5.0)
+        with BudgetSession(ledger) as session:
+            with pytest.raises(InvalidCost):
+                session.track("result", cost=float("-inf"), tool_name="api")
+
+    def test_invalid_cost_does_not_alter_session_state(self):
+        ledger = Ledger(budget=5.0)
+        with BudgetSession(ledger) as session:
+            session.track("a", cost=1.0, tool_name="ok")
+
+            with pytest.raises(InvalidCost):
+                session.track("b", cost=-5.0, tool_name="bad")
+
+            assert session.spent == 1.0
+            assert session.remaining == 4.0
+
+    def test_zero_cost_is_accepted(self):
+        ledger = Ledger(budget=5.0)
+        with BudgetSession(ledger) as session:
+            session.track("result", cost=0.0, tool_name="free")
+            assert session.spent == 0.0
+
+
+# ---------------------------------------------------------------------------
+# BudgetSession.would_exceed() validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestSessionWouldExceedValidation:
+    def test_negative_cost_rejected(self):
+        ledger = Ledger(budget=5.0)
+        with BudgetSession(ledger) as session:
+            with pytest.raises(InvalidCost):
+                session.would_exceed(-1.0)
+
+    def test_nan_cost_rejected(self):
+        ledger = Ledger(budget=5.0)
+        with BudgetSession(ledger) as session:
+            with pytest.raises(InvalidCost):
+                session.would_exceed(float("nan"))
+
+
+# ---------------------------------------------------------------------------
+# Regression: negative cost must never increase remaining budget
+# ---------------------------------------------------------------------------
+
+
+class TestNegativeCostRegression:
+    """Reproduces the scenario from the issue where a negative cost
+    increased the remaining budget to more than the original limit.
+    """
+
+    def test_negative_cost_cannot_increase_remaining(self):
+        ledger = Ledger(budget=1.0)
+        with pytest.raises(InvalidCost):
+            ledger.record(CostEvent(cost=-5.0, cost_type=CostType.TOOL))
+
+        assert ledger.spent == 0.0
+        assert ledger.remaining == 1.0


### PR DESCRIPTION
## Summary

Adds cost validation to prevent invalid values (negative, `NaN`, `Infinity`, `-Infinity`) from corrupting the budget ledger.

Closes #21

## Problem

As described in #21, the current implementation forwards cost values directly into the ledger without validation. This allows callers to:

- **Increase remaining budget** by tracking a negative cost (`track(cost=-5.0)`)
- **Corrupt the ledger** with `NaN` (`track(cost=float('nan'))`)
- **Create impossible budget states** with `±Infinity`

This breaks the core guarantee that a configured budget acts as a hard upper bound on spend.

## Changes

### New exception: `InvalidCost`
- Added `InvalidCost` to `agentbudget/exceptions.py`, a typed subclass of `AgentBudgetError`
- Exported from the top-level package so users can catch it

### Validation helper: `validate_cost()`
- Added to `agentbudget/ledger.py`
- Rejects any value that is: negative, `NaN`, positive infinity, or negative infinity
- Raises `InvalidCost` with a clear message

### Validation applied at two layers (defense in depth)
1. **Public API boundary** — `BudgetSession.track()` and `BudgetSession.would_exceed()` validate before creating any event
2. **Ledger internals** — `Ledger.record()` and `Ledger.would_exceed()` validate before mutating state, ensuring safety even if another caller bypasses the session layer

### Key behavior
- Invalid values are rejected **before** any ledger state is mutated
- `spent`, `remaining`, `breakdown`, and `events` all remain unchanged after a rejected call
- Zero cost (`0.0`) is accepted (valid for free tool calls)

## Tests

29 new tests in `tests/test_cost_validation.py` covering:

- `validate_cost()` unit tests (zero, positive, negative, NaN, ±Infinity)
- `Ledger.record()` rejection and state immutability after rejection
- `Ledger.would_exceed()` rejection
- `BudgetSession.track()` rejection and state immutability
- `BudgetSession.would_exceed()` rejection
- Regression test reproducing the exact scenario from issue #21

All 365 tests pass (including 29 new ones). No existing tests were modified.

## Scope

This PR addresses the **Python SDK** only, as noted in #21. The same validation gap exists in the TypeScript and Go SDKs and can be addressed in follow-up PRs.