### PR TITLE
fix: isolate drop-in budget sessions across concurrent contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,13 @@ print(agentbudget.report())     # Full cost breakdown
 agentbudget.teardown()  # Stop tracking, get final report
 ```
 
-`agentbudget.init()` patches OpenAI and Anthropic SDKs so every call is tracked automatically. `teardown()` restores the originals. Same pattern as Sentry and Datadog.
+`agentbudget.init()` patches OpenAI and Anthropic SDKs so every call is tracked automatically. The patch is process-wide, but the active budget/session is isolated to the current thread or async task. `teardown()` only closes the current context's session, and the SDKs are unpatched after the last active context exits.
+
+For concurrent apps:
+
+- Call `agentbudget.init()` inside each request thread that needs its own session.
+- `asyncio` tasks inherit the current session at task creation; call `agentbudget.init()` inside the task to give it an independent session.
+- For explicit server-side scoping, `wrap_client()` or manual `BudgetSession` usage is still the most predictable option.
 
 ### Manual Mode
 
@@ -160,7 +166,7 @@ See [`/sdks/typescript/README.md`](./sdks/typescript/README.md) for full docs.
 
 | Function | Description |
 |---|---|
-| `agentbudget.init(budget)` | Start tracking. Patches OpenAI/Anthropic. Returns session. |
+| `agentbudget.init(budget)` | Start tracking in the current thread/task context. Returns session. |
 | `agentbudget.spent()` | Total dollars spent so far. |
 | `agentbudget.remaining()` | Dollars left in the budget. |
 | `agentbudget.report()` | Full cost breakdown as a dict. |
@@ -168,8 +174,8 @@ See [`/sdks/typescript/README.md`](./sdks/typescript/README.md) for full docs.
 | `agentbudget.wrap_client(client, session)` | Attach tracking to a specific client instance only. |
 | `agentbudget.register_model(name, input, output)` | Add pricing for a new model at runtime. |
 | `agentbudget.register_models(dict)` | Batch register pricing for multiple models. |
-| `agentbudget.get_session()` | Get the active session for advanced use. |
-| `agentbudget.teardown()` | Stop tracking, unpatch SDKs, return final report. |
+| `agentbudget.get_session()` | Get the active session visible in the current context. |
+| `agentbudget.teardown()` | Stop tracking in the current context and return its final report. |
 
 ---
 
@@ -209,7 +215,7 @@ async for chunk in await client.chat.completions.create(stream=True, stream_opti
 
 ### Explicit Per-Client Tracking
 
-By default, `agentbudget.init()` patches all OpenAI/Anthropic calls globally. If you need finer control — multiple budgets, different clients per task, or just prefer explicit scope — use `wrap_client()`:
+By default, `agentbudget.init()` installs process-wide OpenAI/Anthropic patches and resolves the active session from the current thread/task context at call time. If you need finer control — multiple budgets, different clients per task, or just prefer explicit scope — use `wrap_client()`:
 
 ```python
 from agentbudget import AgentBudget

--- a/agentbudget/_global.py
+++ b/agentbudget/_global.py
@@ -17,19 +17,101 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
+import threading
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
 from .budget import AgentBudget
 from .session import BudgetSession
-from ._patch import patch_openai, patch_anthropic, unpatch_all, wrap_client
+from ._patch import patch_openai, patch_anthropic, unpatch_all
 
-_current_budget: Optional[AgentBudget] = None
-_current_session: Optional[BudgetSession] = None
+
+@dataclass
+class _DropInState:
+    """Context-local state for drop-in auto-instrumentation."""
+
+    session: BudgetSession
+    scope_id: tuple[str, int]
+    token: Optional[Token[Optional["_DropInState"]]] = None
+
+
+_current_state: ContextVar[Optional[_DropInState]] = ContextVar(
+    "agentbudget_current_state",
+    default=None,
+)
+_patch_lock = threading.Lock()
+_active_contexts = 0
+
+
+def _current_scope_id() -> tuple[str, int]:
+    """Identify the current logical execution scope.
+
+    Async tasks get their own scope. Synchronous code falls back to the
+    current thread, which keeps thread-local and task-local init() calls
+    isolated from each other.
+    """
+    try:
+        task = asyncio.current_task()
+    except RuntimeError:
+        task = None
+
+    if task is not None:
+        return ("task", id(task))
+    return ("thread", threading.get_ident())
+
+
+def _get_state() -> Optional[_DropInState]:
+    return _current_state.get()
+
+
+def _owns_state(state: _DropInState) -> bool:
+    return state.scope_id == _current_scope_id()
+
+
+def _acquire_patches() -> None:
+    """Install global SDK patches while at least one context is active."""
+    global _active_contexts
+
+    with _patch_lock:
+        if _active_contexts == 0:
+            patch_openai(_get_session)
+            patch_anthropic(_get_session)
+        _active_contexts += 1
+
+
+def _release_patches() -> None:
+    """Remove global SDK patches after the last active context exits."""
+    global _active_contexts
+
+    with _patch_lock:
+        if _active_contexts == 0:
+            return
+        _active_contexts -= 1
+        if _active_contexts == 0:
+            unpatch_all()
+
+
+def _teardown_state(state: _DropInState) -> dict[str, Any]:
+    """Close an owned session and restore the previous visible context."""
+    try:
+        state.session.__exit__(None, None, None)
+        return state.session.report()
+    finally:
+        if state.token is not None:
+            _current_state.reset(state.token)
+        else:
+            _current_state.set(None)
+        _release_patches()
 
 
 def _get_session() -> Optional[BudgetSession]:
-    """Get the active global session. Used by patched methods."""
-    return _current_session
+    """Get the active context-local session. Used by patched methods."""
+    state = _get_state()
+    if state is None:
+        return None
+    return state.session
 
 
 def init(
@@ -43,20 +125,18 @@ def init(
     webhook_url: Optional[str] = None,
     session_id: Optional[str] = None,
 ) -> BudgetSession:
-    """Initialize global budget tracking with auto-instrumentation.
+    """Initialize budget tracking for the current thread/task context.
 
     Patches OpenAI and Anthropic clients so every LLM call is
     automatically tracked. Call teardown() to stop tracking.
 
     Returns the active BudgetSession for manual tracking if needed.
     """
-    global _current_budget, _current_session
-
-    # Teardown any existing session
-    if _current_session is not None:
+    state = _get_state()
+    if state is not None and _owns_state(state):
         teardown()
 
-    _current_budget = AgentBudget(
+    budget_obj = AgentBudget(
         max_spend=budget,
         soft_limit=soft_limit,
         max_repeated_calls=max_repeated_calls,
@@ -66,59 +146,63 @@ def init(
         on_loop_detected=on_loop_detected,
         webhook_url=webhook_url,
     )
-    _current_session = _current_budget.session(session_id=session_id)
-    _current_session.__enter__()
+    session = budget_obj.session(session_id=session_id)
+    scope_id = _current_scope_id()
 
-    # Patch available SDKs
-    patch_openai(_get_session)
-    patch_anthropic(_get_session)
+    entered = False
+    _acquire_patches()
+    try:
+        session.__enter__()
+        entered = True
+        new_state = _DropInState(session=session, scope_id=scope_id)
+        new_state.token = _current_state.set(new_state)
+    except Exception:
+        if entered:
+            session.__exit__(None, None, None)
+        _release_patches()
+        raise
 
-    return _current_session
+    return session
 
 
 def teardown() -> Optional[dict[str, Any]]:
-    """Stop tracking and unpatch all clients.
+    """Stop tracking in the current context.
 
     Returns the final cost report, or None if not initialized.
     """
-    global _current_budget, _current_session
-
-    report = None
-    if _current_session is not None:
-        _current_session.__exit__(None, None, None)
-        report = _current_session.report()
-
-    unpatch_all()
-    _current_session = None
-    _current_budget = None
-
-    return report
+    state = _get_state()
+    if state is None or not _owns_state(state):
+        return None
+    return _teardown_state(state)
 
 
 def get_session() -> Optional[BudgetSession]:
-    """Get the active global session."""
-    return _current_session
+    """Get the active session visible in the current context."""
+    return _get_session()
 
 
 def spent() -> float:
     """Get total amount spent in the current session."""
-    if _current_session is None:
+    session = _get_session()
+    if session is None:
         return 0.0
-    return _current_session.spent
+    return session.spent
 
 
 def remaining() -> float:
     """Get remaining budget in the current session."""
-    if _current_session is None:
+    session = _get_session()
+    if session is None:
         return 0.0
-    return _current_session.remaining
+    return session.remaining
 
 
 def report() -> Optional[dict[str, Any]]:
     """Get the cost report for the current session."""
-    if _current_session is None:
+    session = _get_session()
+    if session is None:
         return None
-    return _current_session.report()
+    return session.report()
 
 
 def track(
@@ -126,7 +210,8 @@ def track(
     cost: float = 0.0,
     tool_name: Optional[str] = None,
 ) -> Any:
-    """Track a tool/API call cost in the global session."""
-    if _current_session is None:
+    """Track a tool/API call cost in the active context-local session."""
+    session = _get_session()
+    if session is None:
         raise RuntimeError("agentbudget.init() must be called before tracking costs")
-    return _current_session.track(result, cost=cost, tool_name=tool_name)
+    return session.track(result, cost=cost, tool_name=tool_name)

--- a/tests/test_dropin.py
+++ b/tests/test_dropin.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
+import threading
 import types
 from unittest import mock
 
 import pytest
 
 import agentbudget
-from agentbudget._global import _get_session
 
 
 class FakeUsage:
@@ -22,6 +23,44 @@ class FakeResponse:
     def __init__(self, model="gpt-4o", prompt_tokens=100, completion_tokens=50):
         self.model = model
         self.usage = FakeUsage(prompt_tokens, completion_tokens)
+
+
+def _build_fake_openai_modules():
+    """Build a fake openai module tree that matches the SDK patch targets."""
+    openai_mod = types.ModuleType("openai")
+    resources_mod = types.ModuleType("openai.resources")
+    chat_mod = types.ModuleType("openai.resources.chat")
+    completions_mod = types.ModuleType("openai.resources.chat.completions")
+
+    class Completions:
+        def create(self, **kwargs):
+            return FakeResponse(
+                model=kwargs.get("model", "gpt-4o"),
+                prompt_tokens=100,
+                completion_tokens=50,
+            )
+
+    class AsyncCompletions:
+        async def create(self, **kwargs):
+            await asyncio.sleep(kwargs.get("delay", 0))
+            return FakeResponse(
+                model=kwargs.get("model", "gpt-4o"),
+                prompt_tokens=100,
+                completion_tokens=50,
+            )
+
+    completions_mod.Completions = Completions
+    completions_mod.AsyncCompletions = AsyncCompletions
+    chat_mod.completions = completions_mod
+    resources_mod.chat = chat_mod
+    openai_mod.resources = resources_mod
+
+    return {
+        "openai": openai_mod,
+        "openai.resources": resources_mod,
+        "openai.resources.chat": chat_mod,
+        "openai.resources.chat.completions": completions_mod,
+    }, Completions, AsyncCompletions
 
 
 # ---- Tests for global API without patching ----
@@ -107,37 +146,15 @@ class TestPatching:
 
     def teardown_method(self):
         agentbudget.teardown()
-        # Clean up fake modules
+        # Clean up fake provider modules
         for key in list(sys.modules.keys()):
             if key.startswith("openai") or key.startswith("anthropic"):
-                if "fake" in str(type(sys.modules[key])):
-                    del sys.modules[key]
+                del sys.modules[key]
 
     def _install_fake_openai(self):
         """Install a fake openai module that mimics the real SDK structure."""
-        # Create fake module hierarchy
-        openai_mod = types.ModuleType("openai")
-        resources_mod = types.ModuleType("openai.resources")
-        chat_mod = types.ModuleType("openai.resources.chat")
-        completions_mod = types.ModuleType("openai.resources.chat.completions")
-
-        class Completions:
-            def create(self, **kwargs):
-                return FakeResponse(
-                    model=kwargs.get("model", "gpt-4o"),
-                    prompt_tokens=100,
-                    completion_tokens=50,
-                )
-
-        completions_mod.Completions = Completions
-        chat_mod.completions = completions_mod
-        resources_mod.chat = chat_mod
-        openai_mod.resources = resources_mod
-
-        sys.modules["openai"] = openai_mod
-        sys.modules["openai.resources"] = resources_mod
-        sys.modules["openai.resources.chat"] = chat_mod
-        sys.modules["openai.resources.chat.completions"] = completions_mod
+        modules, Completions, _ = _build_fake_openai_modules()
+        sys.modules.update(modules)
 
         return Completions
 
@@ -185,3 +202,143 @@ class TestPatching:
         with pytest.raises(agentbudget.BudgetExhausted):
             for _ in range(10):
                 client.create(model="gpt-4o")
+
+
+class TestConcurrency:
+    def setup_method(self):
+        agentbudget.teardown()
+
+    def teardown_method(self):
+        agentbudget.teardown()
+
+    def test_thread_local_sessions_do_not_leak(self):
+        modules, FakeCompletions, _ = _build_fake_openai_modules()
+        start = threading.Barrier(2)
+        reports = {}
+        errors: list[Exception] = []
+
+        def worker(session_id, tool_cost):
+            try:
+                agentbudget.init(budget="$5.00", session_id=session_id)
+                client = FakeCompletions()
+                start.wait(timeout=5)
+                client.create(model="gpt-4o")
+                agentbudget.track(cost=tool_cost, tool_name=f"tool_{session_id}")
+                reports[session_id] = agentbudget.teardown()
+            except Exception as exc:
+                errors.append(exc)
+                agentbudget.teardown()
+
+        with mock.patch.dict(sys.modules, modules):
+            threads = [
+                threading.Thread(target=worker, args=("thread_a", 0.10)),
+                threading.Thread(target=worker, args=("thread_b", 0.20)),
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        assert not errors
+        assert agentbudget.get_session() is None
+
+        first = reports["thread_a"]
+        second = reports["thread_b"]
+
+        assert first["session_id"] == "thread_a"
+        assert second["session_id"] == "thread_b"
+        assert first["breakdown"]["llm"]["calls"] == 1
+        assert second["breakdown"]["llm"]["calls"] == 1
+        assert set(first["breakdown"]["tools"]["by_tool"]) == {"tool_thread_a"}
+        assert set(second["breakdown"]["tools"]["by_tool"]) == {"tool_thread_b"}
+        assert first["breakdown"]["tools"]["by_tool"]["tool_thread_a"] == pytest.approx(0.10)
+        assert second["breakdown"]["tools"]["by_tool"]["tool_thread_b"] == pytest.approx(0.20)
+
+    def test_teardown_in_one_thread_keeps_other_thread_patched(self):
+        modules, FakeCompletions, _ = _build_fake_openai_modules()
+        ready = threading.Barrier(2)
+        first_torn_down = threading.Event()
+        reports = {}
+        errors: list[Exception] = []
+
+        def first_worker():
+            try:
+                agentbudget.init(budget="$5.00", session_id="first")
+                ready.wait(timeout=5)
+                reports["first"] = agentbudget.teardown()
+            except Exception as exc:
+                errors.append(exc)
+                agentbudget.teardown()
+            finally:
+                first_torn_down.set()
+
+        def second_worker():
+            try:
+                agentbudget.init(budget="$5.00", session_id="second")
+                client = FakeCompletions()
+                ready.wait(timeout=5)
+                assert first_torn_down.wait(timeout=5)
+                client.create(model="gpt-4o")
+                reports["second_mid"] = agentbudget.report()
+                reports["second"] = agentbudget.teardown()
+            except Exception as exc:
+                errors.append(exc)
+                agentbudget.teardown()
+
+        with mock.patch.dict(sys.modules, modules):
+            threads = [
+                threading.Thread(target=first_worker),
+                threading.Thread(target=second_worker),
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        assert not errors
+        assert reports["first"]["session_id"] == "first"
+        assert reports["second_mid"]["session_id"] == "second"
+        assert reports["second_mid"]["breakdown"]["llm"]["calls"] == 1
+        assert reports["second"]["breakdown"]["llm"]["calls"] == 1
+
+    @pytest.mark.asyncio
+    async def test_async_tasks_can_shadow_parent_session_independently(self):
+        modules, _, FakeAsyncCompletions = _build_fake_openai_modules()
+
+        with mock.patch.dict(sys.modules, modules):
+            parent_session = agentbudget.init(budget="$5.00", session_id="parent")
+
+            async def worker(session_id, tool_cost):
+                try:
+                    agentbudget.init(budget="$3.00", session_id=session_id)
+                    client = FakeAsyncCompletions()
+                    await client.create(model="gpt-4o", delay=0)
+                    agentbudget.track(cost=tool_cost, tool_name=f"tool_{session_id}")
+                    report = agentbudget.teardown()
+                    restored = agentbudget.get_session()
+                    return report, restored.session_id if restored else None
+                finally:
+                    current = agentbudget.get_session()
+                    if current is not None and current.session_id == session_id:
+                        agentbudget.teardown()
+
+            child_reports = await asyncio.gather(
+                worker("task_a", 0.10),
+                worker("task_b", 0.20),
+            )
+
+            assert agentbudget.get_session() is parent_session
+            assert agentbudget.report()["breakdown"]["llm"]["calls"] == 0
+            parent_report = agentbudget.teardown()
+
+        first_report, first_restored = child_reports[0]
+        second_report, second_restored = child_reports[1]
+
+        assert first_report["session_id"] == "task_a"
+        assert second_report["session_id"] == "task_b"
+        assert first_report["breakdown"]["llm"]["calls"] == 1
+        assert second_report["breakdown"]["llm"]["calls"] == 1
+        assert first_restored == "parent"
+        assert second_restored == "parent"
+        assert parent_report["session_id"] == "parent"
+        assert parent_report["total_spent"] == 0.0

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -646,45 +646,50 @@ def test_teardown_returns_accurate_final_report():
 
 
 # ===========================================================================
-# 10. Concurrent real calls (thread safety)
+# 10. Concurrent real calls (context isolation)
 # ===========================================================================
 
 
 @_SKIP_OPENAI
-def test_concurrent_real_calls_are_tracked_correctly():
+def test_concurrent_thread_sessions_are_isolated():
     """
-    Two threads making real API calls through the same patched client should
-    each have their costs tracked without corruption.
-
-    NOTE: This test uses the global init() patch so both threads share
-    the same BudgetSession — the Ledger uses a threading.Lock internally.
+    Two threads calling agentbudget.init() independently should keep separate
+    sessions and reports, even though the SDK patch itself is process-wide.
     """
     import threading
     import openai
     import agentbudget
 
-    agentbudget.init(budget="$2.00")
-    client = openai.OpenAI()
     errors: list[Exception] = []
+    reports: list[dict] = []
 
-    def make_call():
+    def make_call(session_id: str):
         try:
+            agentbudget.init(budget="$1.00", session_id=session_id)
+            client = openai.OpenAI()
             client.chat.completions.create(
                 model=_OPENAI_CHEAP_MODEL,
                 messages=[{"role": "user", "content": "Say one word."}],
                 max_tokens=3,
             )
+            report = agentbudget.teardown()
+            assert report is not None
+            reports.append(report)
         except Exception as e:
             errors.append(e)
+            agentbudget.teardown()
 
-    threads = [threading.Thread(target=make_call) for _ in range(2)]
+    threads = [
+        threading.Thread(target=make_call, args=("thread_a",)),
+        threading.Thread(target=make_call, args=("thread_b",)),
+    ]
     for t in threads:
         t.start()
     for t in threads:
         t.join()
 
     assert not errors, f"Thread errors: {errors}"
-
-    r = agentbudget.report()
-    assert r["breakdown"]["llm"]["calls"] == 2
-    assert r["total_spent"] > 0
+    assert len(reports) == 2
+    assert {report["session_id"] for report in reports} == {"thread_a", "thread_b"}
+    assert all(report["breakdown"]["llm"]["calls"] == 1 for report in reports)
+    assert all(report["total_spent"] > 0 for report in reports)


### PR DESCRIPTION
## Description

Replace the drop-in API's process-global active session state with context-local state so concurrent threads and async tasks no longer overwrite, reuse, or tear down each other's sessions. This keeps the existing patched SDK flow intact while making session resolution safe for concurrent workloads.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #20

## Changes Made

- Replaced drop-in module-level active session storage with `ContextVar`-backed context-local state in the Python global API
- Updated drop-in patch lifecycle so one context's `teardown()` does not unpatch or clear another still-active context
- Added regression coverage for thread isolation, async task isolation, teardown isolation, and updated README docs for the supported concurrency model

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`pytest --tb=short -q`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes