### PR TITLE
feat: improve LangChain integration coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,9 +335,12 @@ def my_search(query):
 ```python
 from agentbudget.integrations.langchain import LangChainBudgetCallback
 
-callback = LangChainBudgetCallback(budget="$5.00")
-agent.run("Research competitors", callbacks=[callback])
-print(callback.get_report())
+with LangChainBudgetCallback(
+    budget="$5.00",
+    tool_costs={"search": 0.01},
+) as callback:
+    agent.run("Research competitors", callbacks=[callback])
+    print(callback.get_report())
 ```
 
 ### AutoGen

--- a/agentbudget/integrations/langchain.py
+++ b/agentbudget/integrations/langchain.py
@@ -1,30 +1,33 @@
 """LangChain/LangGraph integration for AgentBudget.
 
-Provides a callback handler that tracks LLM costs automatically.
+Provides a callback handler that tracks LLM and tool costs for LangChain runs.
 
 Usage:
     from agentbudget.integrations.langchain import LangChainBudgetCallback
 
-    callback = LangChainBudgetCallback(budget="$5.00")
-    agent.run(callbacks=[callback])
-
-    print(callback.session.report())
+    with LangChainBudgetCallback(
+        budget="$5.00",
+        tool_costs={"search": 0.01},
+    ) as callback:
+        agent.run(callbacks=[callback])
+        print(callback.get_report())
 
 Requires: langchain-core (optional dependency)
 """
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
-from ..budget import AgentBudget, parse_budget
-from ..ledger import Ledger
+from uuid import UUID
+
+from ..budget import AgentBudget
 from ..pricing import calculate_llm_cost
 from ..session import BudgetSession
-from ..types import CostEvent, CostType
 
 try:
     from langchain_core.callbacks import BaseCallbackHandler
+    from langchain_core.messages import BaseMessage
 
     _HAS_LANGCHAIN = True
 except ImportError:
@@ -34,18 +37,28 @@ except ImportError:
     class BaseCallbackHandler:  # type: ignore[no-redef]
         pass
 
+    class BaseMessage:  # type: ignore[no-redef]
+        pass
+
+
+ToolCostExtractor = Callable[[str, Any, dict[str, Any]], Optional[float]]
+
 
 class LangChainBudgetCallback(BaseCallbackHandler):
     """LangChain callback handler that enforces a per-run budget.
 
-    Tracks LLM call costs in real time and raises BudgetExhausted
-    when the budget is exceeded.
+    Tracks LLM call costs in real time and can optionally track tools via:
+    1. explicit ``metadata={"agentbudget_cost": ...}`` on the tool
+    2. a ``tool_costs`` mapping passed to the callback
+    3. a custom ``tool_cost_extractor`` callback
     """
 
     def __init__(
         self,
         budget: str | float | int,
         session: Optional[BudgetSession] = None,
+        tool_costs: Optional[dict[str, float]] = None,
+        tool_cost_extractor: Optional[ToolCostExtractor] = None,
         **kwargs: Any,
     ):
         if not _HAS_LANGCHAIN:
@@ -56,34 +69,208 @@ class LangChainBudgetCallback(BaseCallbackHandler):
         super().__init__(**kwargs)
         self._agent_budget = AgentBudget(max_spend=budget)
         self.session = session or self._agent_budget.session()
-        self.session.__enter__()
+        self._owns_session = session is None
+        self._closed = False
+        self._tool_costs = tool_costs or {}
+        self._tool_cost_extractor = tool_cost_extractor
+        self._run_models: dict[UUID, str] = {}
+        self._tool_runs: dict[UUID, dict[str, Any]] = {}
+        if self._owns_session:
+            self.session.__enter__()
 
-    def on_llm_end(self, response: Any, **kwargs: Any) -> None:
+    def __enter__(self) -> "LangChainBudgetCallback":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.close(exc_type=exc_type, exc_val=exc_val, exc_tb=exc_tb)
+
+    def close(
+        self,
+        *,
+        exc_type: Any = None,
+        exc_val: Any = None,
+        exc_tb: Any = None,
+    ) -> dict[str, Any]:
+        """Close the underlying budget session and return the final report."""
+        if not self._closed:
+            self._run_models.clear()
+            self._tool_runs.clear()
+            if self._owns_session:
+                self.session.__exit__(exc_type, exc_val, exc_tb)
+            self._closed = True
+        return self.session.report()
+
+    def on_chat_model_start(
+        self,
+        serialized: dict[str, Any],
+        messages: list[list[BaseMessage]],
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> None:
+        """Capture the model name for chat-model runs when available."""
+        model_name = self._extract_model_name(serialized, kwargs)
+        if model_name:
+            self._run_models[run_id] = model_name
+
+    def on_llm_start(
+        self,
+        serialized: dict[str, Any],
+        prompts: list[str],
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> None:
+        """Capture the model name for non-chat LLM runs when available."""
+        del prompts
+        model_name = self._extract_model_name(serialized, kwargs)
+        if model_name:
+            self._run_models[run_id] = model_name
+
+    def on_llm_end(self, response: Any, *, run_id: UUID, **kwargs: Any) -> None:
         """Called when an LLM call finishes. Records the cost."""
-        llm_output = getattr(response, "llm_output", None) or {}
-        token_usage = llm_output.get("token_usage", {})
-        model_name = llm_output.get("model_name")
-
-        input_tokens = token_usage.get("prompt_tokens")
-        output_tokens = token_usage.get("completion_tokens")
-
+        model_name, input_tokens, output_tokens = self._extract_llm_usage(
+            response, run_id=run_id, kwargs=kwargs
+        )
         if model_name and input_tokens is not None and output_tokens is not None:
             cost = calculate_llm_cost(model_name, input_tokens, output_tokens)
             if cost is not None:
-                event = CostEvent(
-                    cost=cost,
-                    cost_type=CostType.LLM,
-                    model=model_name,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
+                self.session.wrap(
+                    _LangChainTrackedResponse(
+                        model=model_name,
+                        input_tokens=input_tokens,
+                        output_tokens=output_tokens,
+                    )
                 )
-                self.session._ledger.record(event)
-                self.session._check_after_record(call_key=model_name)
+        self._run_models.pop(run_id, None)
 
-    def on_tool_end(self, output: str, **kwargs: Any) -> None:
-        """Called when a tool finishes. Override to add cost tracking."""
-        pass
+    def on_tool_start(
+        self,
+        serialized: dict[str, Any],
+        input_str: str,
+        *,
+        run_id: UUID,
+        metadata: Optional[dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Capture tool metadata so costs can be resolved on tool completion."""
+        del input_str
+        tool_name = (
+            serialized.get("name")
+            or serialized.get("id")
+            or kwargs.get("name")
+            or "tool"
+        )
+        self._tool_runs[run_id] = {
+            "tool_name": tool_name,
+            "metadata": metadata.copy() if metadata else {},
+            "serialized": serialized,
+            "kwargs": kwargs,
+        }
+
+    def on_tool_end(self, output: Any, *, run_id: UUID, **kwargs: Any) -> None:
+        """Called when a tool finishes. Tracks cost when configured."""
+        tool_run = self._tool_runs.pop(run_id, {})
+        tool_name = tool_run.get("tool_name", "tool")
+        metadata = dict(tool_run.get("metadata", {}))
+        metadata.update(kwargs.get("metadata") or {})
+
+        cost = kwargs.get("cost")
+        if cost is None:
+            cost = metadata.get("agentbudget_cost")
+        if cost is None:
+            cost = self._tool_costs.get(tool_name)
+        if cost is None and self._tool_cost_extractor is not None:
+            cost = self._tool_cost_extractor(tool_name, output, metadata)
+        if cost is None:
+            return
+
+        self.session.track(
+            output,
+            cost=float(cost),
+            tool_name=tool_name,
+            metadata=metadata or None,
+        )
+
+    def on_tool_error(self, error: BaseException, *, run_id: UUID, **kwargs: Any) -> None:
+        """Clear any pending tool state if the tool errors."""
+        del error, kwargs
+        self._tool_runs.pop(run_id, None)
 
     def get_report(self) -> dict[str, Any]:
         """Get the cost report for this callback's session."""
         return self.session.report()
+
+    def _extract_llm_usage(
+        self,
+        response: Any,
+        *,
+        run_id: UUID,
+        kwargs: dict[str, Any],
+    ) -> tuple[Optional[str], Optional[int], Optional[int]]:
+        llm_output = getattr(response, "llm_output", None) or {}
+        token_usage = llm_output.get("token_usage", {})
+
+        model_name = (
+            llm_output.get("model_name")
+            or llm_output.get("model")
+            or self._run_models.get(run_id)
+            or self._extract_model_name({}, kwargs)
+        )
+        input_tokens = token_usage.get("prompt_tokens")
+        output_tokens = token_usage.get("completion_tokens")
+
+        if input_tokens is not None and output_tokens is not None:
+            return model_name, int(input_tokens), int(output_tokens)
+
+        for generation_group in getattr(response, "generations", []) or []:
+            for generation in generation_group or []:
+                message = getattr(generation, "message", None)
+                if message is None:
+                    continue
+                usage_metadata = getattr(message, "usage_metadata", None) or {}
+                model_name = model_name or self._extract_message_model_name(message)
+                input_tokens = usage_metadata.get("input_tokens")
+                output_tokens = usage_metadata.get("output_tokens")
+                if input_tokens is not None and output_tokens is not None:
+                    return model_name, int(input_tokens), int(output_tokens)
+
+        return model_name, None, None
+
+    def _extract_model_name(
+        self,
+        serialized: dict[str, Any],
+        kwargs: dict[str, Any],
+    ) -> Optional[str]:
+        invocation_params = kwargs.get("invocation_params") or {}
+        metadata = kwargs.get("metadata") or {}
+        return (
+            invocation_params.get("model")
+            or invocation_params.get("model_name")
+            or metadata.get("ls_model_name")
+            or metadata.get("model_name")
+            or serialized.get("name")
+            or serialized.get("id")
+        )
+
+    def _extract_message_model_name(self, message: BaseMessage) -> Optional[str]:
+        response_metadata = getattr(message, "response_metadata", None) or {}
+        additional_kwargs = getattr(message, "additional_kwargs", None) or {}
+        return (
+            response_metadata.get("model_name")
+            or response_metadata.get("model")
+            or additional_kwargs.get("model_name")
+            or additional_kwargs.get("model")
+        )
+
+
+class _LangChainTrackedUsage:
+    def __init__(self, input_tokens: int, output_tokens: int) -> None:
+        self.prompt_tokens = input_tokens
+        self.completion_tokens = output_tokens
+
+
+class _LangChainTrackedResponse:
+    def __init__(self, model: str, input_tokens: int, output_tokens: int) -> None:
+        self.model = model
+        self.usage = _LangChainTrackedUsage(input_tokens, output_tokens)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,9 +1,12 @@
 """Tests for framework integrations."""
 
+from uuid import uuid4
+
 import pytest
 
 from agentbudget import AgentBudget, BudgetExhausted
 from agentbudget.integrations.crewai import CrewAIBudgetMiddleware
+from agentbudget.integrations import langchain as langchain_module
 
 
 def test_langchain_import_without_langchain():
@@ -12,6 +15,160 @@ def test_langchain_import_without_langchain():
 
     with pytest.raises(ImportError, match="langchain-core"):
         LangChainBudgetCallback(budget="$5.00")
+
+
+class _FakeLLMResult:
+    def __init__(self, *, llm_output=None, generations=None):
+        self.llm_output = llm_output or {}
+        self.generations = generations or []
+
+
+class _FakeMessage:
+    def __init__(self, usage_metadata=None, response_metadata=None, additional_kwargs=None):
+        self.usage_metadata = usage_metadata or {}
+        self.response_metadata = response_metadata or {}
+        self.additional_kwargs = additional_kwargs or {}
+
+
+class _FakeGeneration:
+    def __init__(self, message):
+        self.message = message
+
+
+class TestLangChainBudgetCallback:
+    def test_tracks_llm_cost_from_llm_output(self, monkeypatch):
+        monkeypatch.setattr(langchain_module, "_HAS_LANGCHAIN", True)
+
+        callback = langchain_module.LangChainBudgetCallback(budget="$5.00")
+        run_id = uuid4()
+
+        response = _FakeLLMResult(
+            llm_output={
+                "model_name": "gpt-4o",
+                "token_usage": {
+                    "prompt_tokens": 1000,
+                    "completion_tokens": 500,
+                },
+            }
+        )
+
+        callback.on_llm_end(response, run_id=run_id)
+        report = callback.close()
+
+        assert report["total_spent"] == pytest.approx(0.0075, rel=1e-4)
+
+    def test_tracks_usage_metadata_when_llm_output_is_missing(self, monkeypatch):
+        monkeypatch.setattr(langchain_module, "_HAS_LANGCHAIN", True)
+
+        callback = langchain_module.LangChainBudgetCallback(budget="$5.00")
+        run_id = uuid4()
+
+        callback.on_chat_model_start(
+            {"name": "ChatOpenAI"},
+            messages=[],
+            run_id=run_id,
+            invocation_params={"model": "gpt-4o"},
+        )
+        response = _FakeLLMResult(
+            generations=[
+                [
+                    _FakeGeneration(
+                        _FakeMessage(
+                            usage_metadata={
+                                "input_tokens": 1000,
+                                "output_tokens": 500,
+                            }
+                        )
+                    )
+                ]
+            ]
+        )
+
+        callback.on_llm_end(response, run_id=run_id)
+        report = callback.close()
+
+        assert report["total_spent"] == pytest.approx(0.0075, rel=1e-4)
+
+    def test_tracks_tool_costs_from_metadata(self, monkeypatch):
+        monkeypatch.setattr(langchain_module, "_HAS_LANGCHAIN", True)
+
+        callback = langchain_module.LangChainBudgetCallback(budget="$5.00")
+        run_id = uuid4()
+
+        callback.on_tool_start(
+            {"name": "search"},
+            "weather in sf",
+            run_id=run_id,
+            metadata={"agentbudget_cost": 0.25, "provider": "serpapi"},
+        )
+        callback.on_tool_end("sunny", run_id=run_id)
+        report = callback.close()
+
+        assert report["total_spent"] == pytest.approx(0.25)
+        assert report["events"][0]["tool_name"] == "search"
+        assert report["events"][0]["metadata"]["provider"] == "serpapi"
+
+    def test_tracks_tool_costs_from_mapping_and_extractor(self, monkeypatch):
+        monkeypatch.setattr(langchain_module, "_HAS_LANGCHAIN", True)
+
+        extractor_calls = []
+        callback = langchain_module.LangChainBudgetCallback(
+            budget="$5.00",
+            tool_costs={"search": 0.10},
+            tool_cost_extractor=lambda tool_name, output, metadata: (
+                extractor_calls.append((tool_name, output, metadata)) or 0.20
+            ),
+        )
+
+        mapped_run_id = uuid4()
+        callback.on_tool_start({"name": "search"}, "prompt", run_id=mapped_run_id)
+        callback.on_tool_end("mapped", run_id=mapped_run_id)
+
+        extracted_run_id = uuid4()
+        callback.on_tool_start(
+            {"name": "fetch"},
+            "prompt",
+            run_id=extracted_run_id,
+            metadata={"source": "api"},
+        )
+        callback.on_tool_end("extracted", run_id=extracted_run_id)
+        report = callback.close()
+
+        assert report["total_spent"] == pytest.approx(0.30)
+        assert extractor_calls == [("fetch", "extracted", {"source": "api"})]
+
+    def test_does_not_own_user_supplied_session(self, monkeypatch):
+        monkeypatch.setattr(langchain_module, "_HAS_LANGCHAIN", True)
+
+        budget = AgentBudget(max_spend="$5.00")
+        session = budget.session()
+        callback = langchain_module.LangChainBudgetCallback(
+            budget="$5.00",
+            session=session,
+        )
+
+        assert session._start_time is None
+        report = callback.close()
+
+        assert session._end_time is None
+        assert report["duration_seconds"] is None
+
+    def test_context_manager_closes_owned_session(self, monkeypatch):
+        monkeypatch.setattr(langchain_module, "_HAS_LANGCHAIN", True)
+
+        run_id = uuid4()
+        with langchain_module.LangChainBudgetCallback(budget="$5.00") as callback:
+            callback.on_tool_start(
+                {"name": "search"},
+                "query",
+                run_id=run_id,
+                metadata={"agentbudget_cost": 0.05},
+            )
+            callback.on_tool_end("done", run_id=run_id)
+
+        report = callback.get_report()
+        assert report["duration_seconds"] is not None
+        assert report["total_spent"] == pytest.approx(0.05)
 
 
 class TestCrewAIMiddleware:

--- a/website/src/app/docs/page.tsx
+++ b/website/src/app/docs/page.tsx
@@ -477,14 +477,15 @@ async with budget.async_session() as session:
           <CodeBlock lang="bash">{`pip install agentbudget[langchain]`}</CodeBlock>
           <CodeBlock>{`from agentbudget.integrations.langchain import LangChainBudgetCallback
 
-callback = LangChainBudgetCallback(budget="$5.00")
-
-agent.run(
-    "Research competitors in the CRM space",
-    callbacks=[callback]
-)
-
-print(callback.get_report())`}</CodeBlock>
+with LangChainBudgetCallback(
+    budget="$5.00",
+    tool_costs={"search": 0.01},
+) as callback:
+    agent.run(
+        "Research competitors in the CRM space",
+        callbacks=[callback]
+    )
+    print(callback.get_report())`}</CodeBlock>
 
           {/* CrewAI */}
           <h2 id="crewai" className="mb-4 mt-16 border-t border-border pt-8 text-xl font-semibold">


### PR DESCRIPTION
## Summary

Improves the Python LangChain integration so it better supports real LangChain and LangGraph workflows.

This PR keeps the scope limited to the LangChain issue only.

## What changed

- added explicit lifecycle support to `LangChainBudgetCallback`
- added context manager usage via `with LangChainBudgetCallback(...) as callback:`
- added `close()` so the callback can finalize and return a report cleanly
- made session ownership explicit so user-supplied sessions are not implicitly managed
- added model tracking from `on_chat_model_start` and `on_llm_start`
- improved LLM cost extraction by supporting fallback `usage_metadata` paths when `llm_output.token_usage` is not present
- implemented tool tracking through `on_tool_start` and `on_tool_end`
- added support for tool costs via:
  - `metadata["agentbudget_cost"]`
  - a `tool_costs` mapping passed to the callback
  - a custom `tool_cost_extractor`
- added cleanup for pending tool state on tool errors
- updated README and docs examples to reflect the new callback usage

## Why

The existing LangChain integration was quite minimal:
- `on_llm_end` only handled a narrow happy path
- `on_tool_end` was still a stub
- callback lifecycle handling was manual
- test coverage for LangChain behavior was limited

This makes the integration more complete and more usable for practical LangChain and LangGraph runs.

## Tests

Ran:

```bash
python -m pytest tests/test_integrations.py -q
